### PR TITLE
修复出错信息：Unknown Host这个错误可能的原因之一

### DIFF
--- a/Links.php
+++ b/Links.php
@@ -69,6 +69,7 @@ if (isset($_GET['send'])) {
         $http->setData(implode("\n", $urls));
         $http->setHeader('Content-Type', 'text/plain');
         try {
+            $api = trim($api); //经过单步调试，发现api这个字符串前面多了一个空格，导致parse_url无法解析正确的`host`
             $result = $http->send($api);
         } catch (Exception $e) {
             throw new Typecho_Plugin_Exception(_t('对不起, 您的主机不支持远程访问。<br>请检查 curl 扩展、allow_url_fopen和防火墙设置！<br><hr>出错信息：'.$e->getMessage()));


### PR DESCRIPTION
请检查 curl 扩展、allow_url_fopen和防火墙设置！
出错信息：Unknown Host
-------------------------
经过调试发现该错误并不是host的dns解析错误，而是因为$api多了一个空格导致`parse_url`函数无法解析到host参数，直接抛出了`Unknown Host`异常