### PR TITLE
fix: 修复文章 Markdown 格式无法正确识别和AMP页面canonical href为空的问题

### DIFF
--- a/Action.php
+++ b/Action.php
@@ -387,6 +387,23 @@ class AMP_Action extends Typecho_Widget implements Widget_Interface_Do
 
         if (count($article_src) > 0) {
             $article = Typecho_Widget::widget("Widget_Abstract_Contents")->push($article_src);
+            
+            // 修复由于 Widget_Abstract_Contents 无法正确初始化路由而导致 permalink 为空的问题
+            if (empty($article['permalink'])) {
+                $categories = $this->cacheDB->fetchAll($this->cacheDB->select()->from('table.metas')
+                    ->join('table.relationships', 'table.relationships.mid = table.metas.mid')
+                    ->where('table.relationships.cid = ?', $article['cid'])
+                    ->where('table.metas.type = ?', 'category')
+                    ->order('table.metas.order', Typecho_Db::SORT_ASC));
+                $article['category'] = urlencode(current(Typecho_Common::arrayFlatten($categories, 'slug')));
+                $article['directory'] = Typecho_Common::arrayFlatten($categories, 'slug');
+                $date = new Typecho_Date($article['created']);
+                $article['year'] = $date->year;
+                $article['month'] = $date->month;
+                $article['day'] = $date->day;
+                $article['permalink'] = Typecho_Router::url('post', $article, Helper::options()->index);
+            }
+
             $select = $this->cacheDB->select('table.users.screenName')
                 ->from('table.users')
                 ->where('uid = ?', $article['authorId']);

--- a/Action.php
+++ b/Action.php
@@ -392,6 +392,12 @@ class AMP_Action extends Typecho_Widget implements Widget_Interface_Do
                 ->where('uid = ?', $article['authorId']);
             $author = $this->cacheDB->fetchRow($select);
             $article['author'] = $author['screenName'];
+            if (isset($article['text'])) {
+                $article['isMarkdown'] = (0 === strpos($article['text'], '<!--markdown-->'));
+                if ($article['isMarkdown']) {
+                    $article['text'] = substr($article['text'], 15);
+                }
+            }
             if ($article['isMarkdown'] == True) {
                 $article['text'] = Markdown::convert($article['text']);
             } else {


### PR DESCRIPTION
1. fix: 修复文章 Markdown 格式无法正确识别的问题
在 Action.php 的 ArticleBase 方法中补充对 <!--markdown--> 标识的检测逻辑，解决 AMP/MIP 页面底层无法判断文章格式的 bug。

2. fix: 修复由于 Widget_Abstract_Contents 无法正确初始化路由而导致 permalink 为空, 导致canonical href为空的问题

环境：
PHP版本：8.0
Typecho版本：1.3.0

升级后在GSC发现了AMP错误：“存在此问题的 AMP 网页无效。无效的 AMP 网页不会显示在 Google 搜索结果中”。
不确定是PHP版本导致的还是Typecho版本的问题，尝试修改了问题。